### PR TITLE
URL Cleanup

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -15,7 +15,7 @@ repositories {
     mavenCentral();
     // You may define additional repositories, or even remove "mavenCentral()".
     // Read more about repositories here:
-    //   http://www.gradle.org/docs/current/userguide/dependency_management.html#sec:repositories
+    //   https://www.gradle.org/docs/current/userguide/dependency_management.html#sec:repositories
 }
 
 dependencies {

--- a/gfxd-demo-loader/build.gradle
+++ b/gfxd-demo-loader/build.gradle
@@ -22,7 +22,7 @@ configurations {
 
 repositories {
   mavenCentral()
-  maven { url "http://repo.spring.io/libs-snapshot" }
+  maven { url "https://repo.spring.io/libs-snapshot" }
 }
 
 run {

--- a/gfxd-demo-mapreduce/build.gradle
+++ b/gfxd-demo-mapreduce/build.gradle
@@ -29,8 +29,8 @@ configurations {
 
 repositories {
   mavenCentral()
-  maven { url "http://repo.spring.io/milestone" }
-  maven { url "http://repo.spring.io/libs-snapshot" }
+  maven { url "https://repo.spring.io/milestone" }
+  maven { url "https://repo.spring.io/libs-snapshot" }
 }
 
 run {

--- a/gfxd-demo-web/build.gradle
+++ b/gfxd-demo-web/build.gradle
@@ -6,8 +6,8 @@ version = '1.0'
 
 repositories {
   mavenCentral()
-  maven { url "http://repo.spring.io/milestone" }
-  maven { url "http://repo.spring.io/libs-snapshot" }
+  maven { url "https://repo.spring.io/milestone" }
+  maven { url "https://repo.spring.io/libs-snapshot" }
 }
 
 dependencies {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.gradle.org/docs/current/userguide/dependency_management.html migrated to:  
  https://www.gradle.org/docs/current/userguide/dependency_management.html ([https](https://www.gradle.org/docs/current/userguide/dependency_management.html) result 301).
* http://repo.spring.io/libs-snapshot migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* http://repo.spring.io/milestone migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).